### PR TITLE
Move methods from graphix and add Aer methods

### DIFF
--- a/examples/ibm_device.py
+++ b/examples/ibm_device.py
@@ -14,11 +14,10 @@ import networkx as nx
 import random
 from graphix import Circuit
 from graphix_ibmq.runner import IBMQBackend
-from qiskit import IBMQ, transpile
-from qiskit_ibm_provider import IBMProvider
+from qiskit import IBMQ
 from qiskit.tools.visualization import plot_histogram
-from qiskit_aer import AerSimulator
 from qiskit.providers.fake_provider import FakeLagos
+
 
 def cp(circuit, theta, control, target):
     """Controlled phase gate, decomposed"""
@@ -35,28 +34,6 @@ def swap(circuit, a, b):
     circuit.cnot(b, a)
     circuit.cnot(a, b)
 
-def format_result(pattern, result):
-    """Format the result so that only the result corresponding to the output qubit is taken out.
-
-    Returns
-    -------
-    masked_results : dict
-        Dictionary of formatted results.
-    """
-    masked_results = {} 
-    N_node = pattern.Nnode + len(pattern.results)
-
-    # Iterate over original measurement results
-    for key, value in result.get_counts().items():
-        masked_key = ""
-        for idx in pattern.output_nodes:
-            masked_key +=  key[N_node - idx - 1]
-        if masked_key in masked_results:
-            masked_results[masked_key] += value
-        else:
-            masked_results[masked_key] = value
-
-    return masked_results
 
 #%%
 # Now let us define a circuit to apply QFT to three-qubit state.
@@ -69,16 +46,16 @@ psi = {}
 # prepare random state for each input qubit
 for i in range(3):
     theta = random.uniform(0, np.pi)
-    phi = random.uniform(0, 2*np.pi)
+    phi = random.uniform(0, 2 * np.pi)
     circuit.ry(i, theta)
     circuit.rz(i, phi)
-    psi[i] = [np.cos(theta/2), np.sin(theta/2)*np.exp(1j*phi)]
+    psi[i] = [np.cos(theta / 2), np.sin(theta / 2) * np.exp(1j * phi)]
 
 # 8 dimension input statevector
-input_state = [0]*8 
-for i in range(8): 
+input_state = [0] * 8
+for i in range(8):
     i_str = f"{i:03b}"
-    input_state[i] = psi[0][int(i_str[0])]*psi[1][int(i_str[1])]*psi[2][int(i_str[2])]
+    input_state[i] = psi[0][int(i_str[0])] * psi[1][int(i_str[1])] * psi[2][int(i_str[2])]
 
 # QFT
 circuit.h(0)
@@ -113,60 +90,51 @@ print(type(backend.circ))
 #%%
 # Get the API token and load the IBMQ acount.
 
-IBMQ.save_account('MY_API_TOKEN', overwrite=True)
+IBMQ.save_account("MY_API_TOKEN", overwrite=True)
 IBMQ.load_account()
 
 #%%
 # Get provider and the backend.
 
-instance_name = 'ibm-q/open/main'
+instance_name = "ibm-q/open/main"
 backend_name = "ibm_lagos"
 
-provider = IBMProvider(instance=instance_name)
-backend = provider.get_backend(backend_name)
-print(f"Using backend {backend.name}")
+backend.get_backend(instance=instance_name, resource=backend_name)
 
 #%%
 # We can now execute the circuit on the device backend.
 
-circ_device = transpile(backend.circ, backend)
-job = backend.run(circ_device, shots=1024, dynamic=True)
-print(f"Your job's id: {job.job_id()}")
-result = format_result(pattern, job.result())
+result = backend.run()
 
 #%%
 # Retrieve the job if needed
 
-# job = provider.backend.retrieve_job("Job ID")
-# result = format_result(pattern, job.result())
+# result = backend.retrieve_result("Job ID")
 
 #%%
 # We can simulate the circuit with noise model based on the device we used
 
 # get the noise model of the device backend
 backend_noisemodel = FakeLagos()
-sim_noise = AerSimulator.from_backend(backend_noisemodel)
 
-# transpile the circuit for the noisy basis gates
-circ_noise = transpile(backend.circ, sim_noise)
 # execute noisy simulation and get counts
-result_noise = format_result(pattern, sim_noise.run(circ_noise).result())
+result_noise = backend.simulate(noise_model=backend_noisemodel)
 
 #%%
 # Now let us compare the results with theoretical output
 
 # calculate the theoretical output state
-state = [0]*8
-omega = np.exp(1j*np.pi/4)
+state = [0] * 8
+omega = np.exp(1j * np.pi / 4)
 
 for i in range(8):
     for j in range(8):
-        state[i] += input_state[j]*omega**(i*j)/2**1.5
+        state[i] += input_state[j] * omega ** (i * j) / 2**1.5
 
 # calculate the theoretical counts
 count_theory = {}
 for i in range(2**3):
-    count_theory[f"{i:03b}"] = 1024*np.abs(state[i])**2
+    count_theory[f"{i:03b}"] = 1024 * np.abs(state[i]) ** 2
 
 # plot and compare the results
 plot_histogram(

--- a/graphix_ibmq/runner.py
+++ b/graphix_ibmq/runner.py
@@ -21,6 +21,8 @@ class IBMQBackend:
         instance name of IBMQ provider.
     resource : str
         resource name of IBMQ provider.
+    backend : :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` object
+        IBMQ device backend
     """
 
     def __init__(self, pattern):
@@ -42,10 +44,6 @@ class IBMQBackend:
             instance name of IBMQ provider.
         resource : str
             resource name of IBMQ provider.
-        backend : :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` object
-            IBMQ device backend
-        circ : :class:`qiskit.circuit.quantumcircuit.QuantumCircuit` object
-            qiskit circuit corresponding to the pattern.
         """
         self.instance = instance
         self.provider = IBMProvider(instance=self.instance)
@@ -185,6 +183,8 @@ class IBMQBackend:
 
         Parameters
         ----------
+        backend : :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` object, optional
+            backend to be used for transpilation.
         optimization_level : int, optional
             the optimization level of the transpilation.
         """
@@ -203,11 +203,11 @@ class IBMQBackend:
             noise model to be used in the simulation.
         format_result : bool, optional
             whether to format the result so that only the result corresponding to the output qubit is taken out.
+
         Returns
         ----------
-        result :
-            the measurement result,
-            in the representation depending on the backend used.
+        result : dict
+            the measurement result.
         """
         if noise_model is not None:
             if type(noise_model) is NoiseModel:
@@ -226,11 +226,19 @@ class IBMQBackend:
     def run(self, shots=1024, format_result=True, optimization_level=1):
         """Perform the execution.
 
+        Parameters
+        ----------
+        shots : int, optional
+            the number of shots.
+        format_result : bool, optional
+            whether to format the result so that only the result corresponding to the output qubit is taken out.
+        optimization_level : int, optional
+            the optimization level of the transpilation.
+
         Returns
         -------
-        result :
-            the measurement result,
-            in the representation depending on the backend used.
+        result : dict
+            the measurement result.
         """
         self.transpile(optimization_level=optimization_level)
         self.job = self.backend.run(self.circ, shots=shots, dynamic=True)
@@ -267,11 +275,17 @@ class IBMQBackend:
     def retrieve_result(self, job_id, format_result=True):
         """Retrieve the execution result.
 
+        Parameters
+        ----------
+        job_id : str
+            the id of the job.
+        format_result : bool, optional
+            whether to format the result so that only the result corresponding to the output qubit is taken out.
+
         Returns
         -------
-        result :
-            the measurement result,
-            in the representation depending on the backend used.
+        result : dict
+            the measurement result.
         """
         self.job = self.provider.retrieve_job(job_id)
         result = self.job.result()

--- a/tests/test_ibmq_interface.py
+++ b/tests/test_ibmq_interface.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from qiskit import Aer, transpile
+from qiskit_aer import AerSimulator
 from graphix_ibmq.runner import IBMQBackend
 import tests.random_circuit as rc
 
@@ -27,11 +27,10 @@ class TestIBMQInterface(unittest.TestCase):
         state = pattern.simulate_pattern()
 
         ibmq_backend = IBMQBackend(pattern)
-        simulator = Aer.get_backend("aer_simulator")
         ibmq_backend.to_qiskit(save_statevector=True)
-        qiskit_circuit = transpile(ibmq_backend.circ, simulator)
-        sim_result = simulator.run(qiskit_circuit).result()
-        state_qiskit = sim_result.get_statevector(qiskit_circuit)
+        ibmq_backend.transpile(backend=AerSimulator())
+        sim_result = ibmq_backend.simulate(format_result=False)
+        state_qiskit = sim_result.get_statevector(ibmq_backend.circ)
         state_qiskit_mod = modify_statevector(state_qiskit, ibmq_backend.circ_output)
 
         np.testing.assert_almost_equal(np.abs(np.dot(state_qiskit_mod.conjugate(), state.flatten())), 1)

--- a/tests/test_ibmq_interface.py
+++ b/tests/test_ibmq_interface.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-from qiskit_aer import AerSimulator
 from graphix_ibmq.runner import IBMQBackend
 import tests.random_circuit as rc
 
@@ -28,7 +27,6 @@ class TestIBMQInterface(unittest.TestCase):
 
         ibmq_backend = IBMQBackend(pattern)
         ibmq_backend.to_qiskit(save_statevector=True)
-        ibmq_backend.transpile(backend=AerSimulator())
         sim_result = ibmq_backend.simulate(format_result=False)
         state_qiskit = sim_result.get_statevector(ibmq_backend.circ)
         state_qiskit_mod = modify_statevector(state_qiskit, ibmq_backend.circ_output)


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `pytest`)
- format added code and tests by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).
 
Then, please fill in below:

**Context (if applicable):**
We need to organize methods with graphix/PatternRunner and add methods for Aer simulation.

**Description of the change:**
Add Aer simulation method. Move some methods from graphix/PatternRunner

**Related issue:**
#6 

also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



