### PR TITLE
Update for compatibility with Qiskit 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated to support Qiskit 1.0.
 
 ### Fixed
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -212,3 +212,33 @@ Now let us compare the results with theoretical prediction
 .. figure:: ./../imgs/execution_output.png
    :scale: 85 %
    :alt: execution results with simulation and theoretical output
+
+This is a tutorial on how to run a pattern on IBM Quantum devices.
+
+.. code-block:: python
+
+    # Example demonstrating how to run a pattern on an IBM Quantum device. All explanations are provided as comments.
+
+    # First, load the IBMQ account using an API token.
+    """
+    from qiskit_ibm_runtime import QiskitRuntimeService
+    service = QiskitRuntimeService(channel="ibm_quantum", token="your_ibm_token", instance="ibm-q/open/main")
+    """
+
+    # Then, select the quantum system on which to run the circuit.
+    # If no system is specified, the least busy system will be automatically selected.
+    """
+    backend.get_system(service, "ibm_kyoto")
+    """
+
+    # Finally, transpile the quantum circuit for the chosen system and execute it.
+    """
+    backend.transpile()
+    result = backend.run(shots=128)
+    """
+
+    # To retrieve the result at a later time, use the code below.
+    """
+    result = backend.retrieve_result("your_job_id")
+    """
+    

--- a/examples/gallery/aer_sim.py
+++ b/examples/gallery/aer_sim.py
@@ -67,7 +67,7 @@ circuit.h(2)
 swap(circuit, 0, 2)
 
 # transpile and plot the graph
-pattern = circuit.transpile()
+pattern = circuit.transpile().pattern
 nodes, edges = pattern.get_graph()
 g = nx.Graph()
 g.add_nodes_from(nodes)
@@ -85,7 +85,6 @@ pattern.minimize_space()
 
 # convert to qiskit circuit
 backend = IBMQBackend(pattern)
-backend.to_qiskit()
 print(type(backend.circ))
 
 #%%
@@ -137,4 +136,32 @@ plot_histogram([count_theory, result, result_noise],
                bar_labels=False)
 legend = ax.legend(fontsize=18)
 legend = ax.legend(loc='upper left')
+# %%
+
+
+#%%
+# Example demonstrating how to run a pattern on an IBM Quantum device. All explanations are provided as comments.
+
+# First, load the IBMQ account using an API token.
+"""
+from qiskit_ibm_runtime import QiskitRuntimeService
+service = QiskitRuntimeService(channel="ibm_quantum", token="your_ibm_token", instance="ibm-q/open/main")
+"""
+
+# Then, select the quantum system on which to run the circuit.
+# If no system is specified, the least busy system will be automatically selected.
+"""
+backend.get_system(service, "ibm_kyoto")
+"""
+
+# Finally, transpile the quantum circuit for the chosen system and execute it.
+"""
+backend.transpile()
+result = backend.run(shots=128)
+"""
+
+# To retrieve the result at a later time, use the code below.
+"""
+result = backend.retrieve_result("your_job_id")
+"""
 # %%

--- a/graphix_ibmq/converter.py
+++ b/graphix_ibmq/converter.py
@@ -26,11 +26,11 @@ def qiskit_to_graphix(qc: QuantumCircuit) -> Circuit:
         circuit.h(idx)
     for ci in qc.data:
         if ci.operation.name == "rx":
-            circuit.rx(ci.qubits[0].index, ci.operation.params[0])
+            circuit.rx(ci.qubits[0]._index, ci.operation.params[0])
         elif ci.operation.name == "rz":
-            circuit.rz(ci.qubits[0].index, ci.operation.params[0])
+            circuit.rz(ci.qubits[0]._index, ci.operation.params[0])
         elif ci.operation.name == "cx":
-            circuit.cnot(ci.qubits[0].index, ci.qubits[1].index)
+            circuit.cnot(ci.qubits[0]._index, ci.qubits[1]._index)
         else:
             raise ValueError(f"QuantumCircuit must not contain non-unitary component: {ci.operation.name}")
 

--- a/graphix_ibmq/runner.py
+++ b/graphix_ibmq/runner.py
@@ -273,17 +273,8 @@ class IBMQBackend:
         else:
             simulator = AerSimulator()
         circ_sim = transpile(self.circ, simulator)
-        sampler = SamplerV2(simulator)
-        job = sampler.run([circ_sim], shots=shots)
+        job = simulator.run(circ_sim, shots=shots)
         result = job.result()
-        result = next(
-            (
-                getattr(result[0].data, attr_name)
-                for attr_name in dir(result[0].data)
-                if attr_name.startswith("c") and attr_name[1:].isdigit()
-            ),
-            None,
-        )
         if format_result:
             result = self.format_result(result)
 

--- a/graphix_ibmq/runner.py
+++ b/graphix_ibmq/runner.py
@@ -59,7 +59,7 @@ class IBMQBackend:
             self.system = self.service.backend(system)
         else:
             self.system = self.service.least_busy(min_num_qubits=self.pattern.max_space(), operational=True)
-        
+
         print(f"Using system {self.system.name}")
 
     def to_qiskit(self, save_statevector: bool = False):
@@ -101,7 +101,7 @@ class IBMQBackend:
                     else:
                         if self.pattern.results[s] == 1:
                             circ.z(circ_idx)
-                            
+
         for i in self.pattern.input_nodes:
             circ_idx = empty_qubit[0]
             empty_qubit.pop(0)
@@ -110,7 +110,7 @@ class IBMQBackend:
             qubit_dict[i] = circ_idx
 
         for cmd in self.pattern:
-            
+
             if cmd[0] == "N":
                 circ_idx = empty_qubit[0]
                 empty_qubit.pop(0)
@@ -276,8 +276,14 @@ class IBMQBackend:
         sampler = SamplerV2(simulator)
         job = sampler.run([circ_sim], shots=shots)
         result = job.result()
-        result = next((getattr(result[0].data, attr_name) for attr_name in dir(result[0].data)
-                        if attr_name.startswith('c') and attr_name[1:].isdigit()), None)
+        result = next(
+            (
+                getattr(result[0].data, attr_name)
+                for attr_name in dir(result[0].data)
+                if attr_name.startswith("c") and attr_name[1:].isdigit()
+            ),
+            None,
+        )
         if format_result:
             result = self.format_result(result)
 
@@ -303,12 +309,18 @@ class IBMQBackend:
         self.transpile(optimization_level=optimization_level)
         if not hasattr(self, "system"):
             raise ValueError("No system is set.")
-        sampler = SamplerV2(backend=self.system) 
+        sampler = SamplerV2(backend=self.system)
         job = sampler.run([self.circ], shots=shots)  # Pass the circuit and shot count to the run method
         print(f"Your job's id: {job.job_id()}")
         result = job.result()
-        result = next((getattr(result[0].data, attr_name) for attr_name in dir(result[0].data)
-                        if attr_name.startswith('c') and attr_name[1:].isdigit()), None)
+        result = next(
+            (
+                getattr(result[0].data, attr_name)
+                for attr_name in dir(result[0].data)
+                if attr_name.startswith("c") and attr_name[1:].isdigit()
+            ),
+            None,
+        )
         if format_result:
             result = self.format_result(result)
 
@@ -357,8 +369,14 @@ class IBMQBackend:
             raise ValueError("No service is set.")
         job = self.service.job(job_id)
         result = job.result()
-        result = next((getattr(result[0].data, attr_name) for attr_name in dir(result[0].data)
-                        if attr_name.startswith('c') and attr_name[1:].isdigit()), None)
+        result = next(
+            (
+                getattr(result[0].data, attr_name)
+                for attr_name in dir(result[0].data)
+                if attr_name.startswith("c") and attr_name[1:].isdigit()
+            ),
+            None,
+        )
         if format_result:
             result = self.format_result(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.22,<1.26
-qiskit>1.0
+qiskit>=1.0
 qiskit_ibm_runtime
 qiskit-aer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.22,<1.26
-qiskit==0.42
-qiskit-ibm-provider>=0.5
+qiskit>1.0
+qiskit_ibm_runtime
 qiskit-aer

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ info = {
     ],
     "python_requires": ">=3.8,<3.12",
     "install_requires": requirements,
-    "extras_require": {"test": ["graphix==0.2.8"]},
+    "extras_require": {"test": ["graphix"]},
 }
 
 setup(**(info))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -16,5 +16,5 @@ class TestConverter(unittest.TestCase):
         sv = Statevector.from_instruction(qc)
         sv = sv.reverse_qargs()
         gx_sv = gx_qc.simulate_statevector()
-        gx_sv = Statevector(gx_sv.flatten())
+        gx_sv = Statevector(gx_sv.statevec.flatten())
         self.assertTrue(sv.equiv(gx_sv))

--- a/tests/test_ibmq_interface.py
+++ b/tests/test_ibmq_interface.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 
-#import tests.random_circuit as rc
 import random_circuit as rc
 from graphix_ibmq.runner import IBMQBackend
 
@@ -25,7 +24,7 @@ class TestIBMQInterface(unittest.TestCase):
         depth = 5
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         state = pattern.simulate_pattern()
 
         ibmq_backend = IBMQBackend(pattern)
@@ -41,7 +40,7 @@ class TestIBMQInterface(unittest.TestCase):
         depth = 5
         pairs = [(i, np.mod(i + 1, nqubits)) for i in range(nqubits)]
         circuit = rc.generate_gate(nqubits, depth, pairs)
-        pattern = circuit.transpile()
+        pattern = circuit.transpile().pattern
         pattern.perform_pauli_measurements()
         pattern.minimize_space()
         state = pattern.simulate_pattern()

--- a/tests/test_ibmq_interface.py
+++ b/tests/test_ibmq_interface.py
@@ -2,7 +2,8 @@ import unittest
 
 import numpy as np
 
-import tests.random_circuit as rc
+#import tests.random_circuit as rc
+import random_circuit as rc
 from graphix_ibmq.runner import IBMQBackend
 
 


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `tox`)
- format added code by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).

Then, please fill in below:

**Context (if applicable):**
The current implementation is not compatible with the latest version of qiskit.

**Description of the change:**
This update includes a series of modifications to the codebase to ensure compatibility with Qiskit 1.0. Apart from the modifications on how to load the IBM quantum device, the external behavior of the module remains unchanged.

**Related issue:**


also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



