### PR TITLE
Update for graphix upstream (input nodes and command objects)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.22,<1.26
-qiskit==0.42
+qiskit>=1.0.2,<1.3
 qiskit-ibm-provider>=0.5
 qiskit-aer


### PR DESCRIPTION
This commit introduces the following changes:
- Preparation of input nodes (since graphix [0.2.11](https://github.com/TeamGraphix/graphix/releases/tag/v0.2.11), input nodes are not prepared by `N` commands).
- Compatibility with `Command` objects introduced in graphix upstream.