### PR TITLE
Signal Processing with Classical Bits

### DIFF
--- a/graphix_ibmq/runner.py
+++ b/graphix_ibmq/runner.py
@@ -12,7 +12,7 @@ from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime import QiskitRuntimeService, IBMBackend, SamplerV2
 
 from graphix_ibmq.clifford import CLIFFORD_TO_QISKIT
-from graphix.command import CommandKind# need to solve circular import
+from graphix.command import CommandKind  # need to solve circular import
 from graphix.pauli import Plane
 
 from qiskit.circuit.classical import expr
@@ -94,7 +94,7 @@ class IBMQBackend:
                     expr_parity = reduce(expr.bit_xor, vars)
                     with circ.if_test(expr_parity):
                         circ.x(circ_idx)
-                    
+
             if op == "Z":
                 vars = [expr.lift(circ.clbits[register_dict[s]]) for s in signal]
                 if len(vars) != 0:
@@ -127,7 +127,7 @@ class IBMQBackend:
                 alpha = cmd.angle * np.pi
                 s_list = cmd.s_domain
                 t_list = cmd.t_domain
-                
+
                 if plane == Plane.XY:
                     # act p and h to implement non-Z-basis measurement
                     if alpha != 0:
@@ -141,7 +141,7 @@ class IBMQBackend:
                     register_dict[cmd.node] = reg_idx
                     reg_idx += 1
                     empty_qubit.append(circ_idx)  # liberate the circuit qubit
-                    
+
                 else:
                     raise NotImplementedError("Non-XY plane is not supported.")
 

--- a/graphix_ibmq/runner.py
+++ b/graphix_ibmq/runner.py
@@ -11,10 +11,9 @@ from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime import QiskitRuntimeService, IBMBackend, SamplerV2
 
-from graphix_ibmq.clifford import CLIFFORD_CONJ, CLIFFORD_TO_QISKIT
-from graphix import clifford, command
-from graphix.command import Command, CommandKind
-from graphix.pauli import Pauli, Plane, Sign
+from graphix_ibmq.clifford import CLIFFORD_TO_QISKIT
+from graphix.command import CommandKind# need to solve circular import
+from graphix.pauli import Plane
 
 from qiskit.circuit.classical import expr
 from functools import reduce


### PR DESCRIPTION
Before submitting, please check the following:
- Make sure you have tests for the new code and that test passes (run `tox`)
- format added code by `black -l 120 <filename>`
- If applicable, add a line to the [unreleased] part of CHANGELOG.md, following [keep-a-changelog](https://keepachangelog.com/en/1.0.0/).

Then, please fill in below:

**Context (if applicable):**
Previously, when a node has corrections from multiple nodes, gate operations according to the measurement results were applied for each correction node individually. In the new version of Qiskit (> 1.0), the capabilities of classical expressions have been enhanced, allowing for signal processing at the classical bit level. It is preferable to perform XOR processing on multiple signals using classical bits and then apply the gate operation only once based on the result.

**Description of the change:**
- Modified the implementation of `signal_process` function in the IBMQ backend so that it uses Qiskit’s classical expressions for signal processing.
- Made revisions to match the specification changes of `pattern` in `graphix`.

**Related issue:**


also see that checks (github actions) pass.
If lint check keeps failing, try installing black==22.8.0 as behavior seems to vary across versions.



